### PR TITLE
Refatora Dockerfile para compatibilidade com o projeto atual e adiciona suporte a SSL em runtime

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -179,5 +179,11 @@ cython_debug/
 *.md
 tests/
 
-#certs
+# Frontend build artifacts
+node_modules/
+
+# Cache Folder
+/src/app/proxy/cache/*
+
+# Cerficates
 certs/

--- a/.dockerignore
+++ b/.dockerignore
@@ -178,3 +178,6 @@ cython_debug/
 .gitignore
 *.md
 tests/
+
+#certs
+certs/

--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,4 @@
+# http/https
+APP_ADDRESS=http
+#APP_ADDRESS=0.0.0.0:6222
+#DISABLE_CACHE=false

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Além dos scrapers, a ferramenta conta com um servidor próprio, desenvolvido em
 # Instalação
 ## Stremio (Windows - localhost)
 ### 1. Baixe a ferramenta openssl
-Algumas fontes não funcionam com o proxy padrão do Stremio e precisam ser acessadas por um proxy customizado que, nesse caso, será hospedado no localhost. Porém, o Stremio exige uma conexão HTTPS para streams até mesmo no localhost, o que significa que o servidor local precisa de um certificado SLL confiável, o qual pode ser facilmente criado usando a ferramenta `openssl`.
+Algumas fontes não funcionam com o proxy padrão do Stremio e precisam ser acessadas por um proxy customizado que, nesse caso, será hospedado no localhost. Porém, o Stremio exige uma conexão HTTPS para streams até mesmo no localhost, o que significa que o servidor local precisa de um certificado SSL confiável, o qual pode ser facilmente criado usando a ferramenta `openssl`.
 #### Chocolatey
 Execute o seguinte comando para instalar o openssl usando Chocolatey:
 ```console
@@ -25,7 +25,7 @@ Navegue ao diretório onde o arquivo `ssl.conf` está localizado e execute o seg
 ```console
 openssl req -x509 -nodes -days 3650 -newkey rsa:2048 -keyout localhost.key -out localhost.crt -config ssl.conf -extensions v3_req
 ```
-Isso criará os arquivos `localhost.crt` e `localhost.key`.
+Isso criará os arquivos `localhost.crt` e `localhost.key`,**Garanta que ambos estejam na pasta certs no diretorio raiz do projeto.**.
 
 ### 3. Adicione o certificado à lista de certificados confiáveis do Windows
 1. No gerenciador de arquivos, navegue ao diretório onde os arquivos da etapa anterior foram criados e clique com o botão esquerdo duas vezes no arquivo `localhost.crt`
@@ -53,7 +53,7 @@ pip install uv
 Escolha alguma das várias opções de instalação disponíveis no [site da ferramenta](https://docs.astral.sh/uv/getting-started/installation/#installation-methods).
 
 ### 5. Instale as dependências do projeto
-Navegue ao diretório raiz do projeo e execute o seguinte comando para instalar as dependências usando a ferramenta uv:
+Navegue ao diretório raiz do projeto e execute o seguinte comando para instalar as dependências usando a ferramenta uv:
 ```console
 uv sync
 ```

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -47,3 +47,5 @@ RUN --mount=type=cache,target=/root/.cache/uv \
 # non root user
 RUN adduser -D appuser && chown -R appuser:appuser /app
 USER appuser
+
+CMD ["uv", "run", "manage.py", "runserver"]

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,5 +1,16 @@
-FROM ghcr.io/astral-sh/uv:python3.13-alpine
+# --- Build frontend ---
+FROM node:alpine AS css-builder
+WORKDIR /build
 
+# copy build artifacts
+COPY package.json package-lock.json ./
+RUN npm ci
+COPY ../src ./src/
+
+RUN npm run build
+
+# --- Final image ---
+FROM ghcr.io/astral-sh/uv:python3.13-alpine AS final
 # Install the project into `/app`
 WORKDIR /app
 
@@ -22,7 +33,14 @@ RUN --mount=type=cache,target=/root/.cache/uv \
     uv sync --locked --no-install-project
 
 
-COPY .. /app
+COPY src/ ./src/
+COPY manage.py uv.lock pyproject.toml selected-media.json ./
+
+COPY --from=css-builder /build/src/app/website/static/css/output.css /src/app/website/static/css/output.css
+
+# remove input.css
+RUN rm -f /src/app/website/static/css/input.css
+
 RUN --mount=type=cache,target=/root/.cache/uv \
     uv sync --locked
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,25 +1,31 @@
-FROM python:3.13.3-slim-bullseye
+FROM ghcr.io/astral-sh/uv:python3.13-alpine
 
+# Install the project into `/app`
 WORKDIR /app
 
-# install build tools
-RUN apt-get update && \
-    apt-get install -y --no-install-recommends \
-    build-essential \
-    curl && \
-    rm -rf /var/lib/apt/lists/*
+# Enable bytecode compilation
+ENV UV_COMPILE_BYTECODE=1
 
-# install rust
-RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
-ENV PATH="/root/.cargo/bin:${PATH}"
+# Copy from the cache instead of linking since it's a mounted volume
+ENV UV_LINK_MODE=copy
 
-# copy and install requirements
-COPY requirements.txt .
-RUN pip install --no-cache-dir -r requirements.txt
+# Omit development dependencies
+ENV UV_NO_DEV=1
 
-# copy the rest of the app
-COPY . .
+# Ensure installed tools can be executed out of the box
+ENV UV_TOOL_BIN_DIR=/usr/local/bin
+
+# Install the project's dependencies using the lockfile and settings
+RUN --mount=type=cache,target=/root/.cache/uv \
+    --mount=type=bind,source=uv.lock,target=uv.lock \
+    --mount=type=bind,source=pyproject.toml,target=pyproject.toml \
+    uv sync --locked --no-install-project
+
+
+COPY .. /app
+RUN --mount=type=cache,target=/root/.cache/uv \
+    uv sync --locked
 
 # non root user
-RUN useradd -m appuser && chown -R appuser:appuser /app
+RUN adduser -D appuser && chown -R appuser:appuser /app
 USER appuser

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -3,6 +3,7 @@ FROM ghcr.io/astral-sh/uv:python3.13-alpine
 # Install the project into `/app`
 WORKDIR /app
 
+RUN mkdir /certs
 # Enable bytecode compilation
 ENV UV_COMPILE_BYTECODE=1
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -3,7 +3,6 @@ FROM ghcr.io/astral-sh/uv:python3.13-alpine
 # Install the project into `/app`
 WORKDIR /app
 
-RUN mkdir /certs
 # Enable bytecode compilation
 ENV UV_COMPILE_BYTECODE=1
 

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -3,11 +3,13 @@ version: '3.8'
 services:
   app:
     working_dir: /app
-    build: .
+    build:
+      context: ..
+      dockerfile: docker/Dockerfile
     ports:
       - "6222:6222" 
     environment:
       - PYTHONUNBUFFERED=1
       - PYTHONDONTWRITEBYTECODE=1
     restart: unless-stopped
-    command: uvicorn main:app --host=0.0.0.0 --port=6222
+    command: uv run manage.py runserver http --address 0.0.0.0:6222

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -1,5 +1,3 @@
-version: '3.8'
-
 services:
   app:
     working_dir: /app
@@ -11,4 +9,5 @@ services:
     volumes:
       - ../certs:/app/certs:ro
     restart: unless-stopped
-    command: uv run manage.py runserver https
+    env_file:
+      - ../.env

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -8,8 +8,7 @@ services:
       dockerfile: docker/Dockerfile
     ports:
       - "6222:6222" 
-    environment:
-      - PYTHONUNBUFFERED=1
-      - PYTHONDONTWRITEBYTECODE=1
+    volumes:
+      - ../certs:/app/certs:ro
     restart: unless-stopped
-    command: uv run manage.py runserver http --address 0.0.0.0:6222
+    command: uv run manage.py runserver https

--- a/manage.py
+++ b/manage.py
@@ -1,7 +1,9 @@
 import argparse
 import asyncio
-
+import os
 import uvicorn
+from dotenv import load_dotenv
+load_dotenv()
 
 
 def runserver(protocol: str, address: str, disable_cache: bool):
@@ -70,10 +72,9 @@ def main():
         help="Starts the http/https server.",
     )
     runserver_parser.add_argument(
-        "protocol",
-        choices=["http", "https"],
-        default="http",
-        help="The protocol used used by the server.",
+    "--protocol",
+    choices=["http", "https"],
+    help="Protocol used by the server (overrides APP_PROTOCOL).",
     )
     runserver_parser.add_argument(
         "--address",
@@ -99,7 +100,21 @@ def main():
     args = parser.parse_args()
     match args.command:
         case "runserver":
-            runserver(args.protocol, args.address, args.disable_cache)
+            protocol = (
+                args.protocol
+                or os.getenv("APP_PROTOCOL", "http")
+            )
+
+            address = (
+                args.address
+                or os.getenv("APP_ADDRESS", "0.0.0.0:6222")
+            )
+
+            disable_cache = (
+                args.disable_cache
+                or os.getenv("DISABLE_CACHE", "false").lower() == "true"
+            )
+            runserver(protocol, address, disable_cache)
 
         case "clearcache":
             asyncio.run(clearcache())

--- a/manage.py
+++ b/manage.py
@@ -29,8 +29,8 @@ def runserver(protocol: str, address: str, disable_cache: bool):
                 app,
                 host=host,
                 port=int(port),
-                ssl_certfile="localhost.crt",
-                ssl_keyfile="localhost.key",
+                ssl_certfile="certs/localhost.crt",
+                ssl_keyfile="certs/localhost.key",
             )
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,6 +11,7 @@ dependencies = [
     "beautifulsoup4>=4.13.4",
     "fastapi>=0.115.12",
     "jinja2>=3.1.6",
+    "python-dotenv>=1.2.1",
     "sqlalchemy>=2.0.41",
     "uvicorn>=0.34.2",
 ]

--- a/uv.lock
+++ b/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 2
+revision = 3
 requires-python = ">=3.13"
 
 [[package]]
@@ -409,6 +409,15 @@ wheels = [
 ]
 
 [[package]]
+name = "python-dotenv"
+version = "1.2.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f0/26/19cadc79a718c5edbec86fd4919a6b6d3f681039a2f6d66d14be94e75fb9/python_dotenv-1.2.1.tar.gz", hash = "sha256:42667e897e16ab0d66954af0e60a9caa94f0fd4ecf3aaf6d2d260eec1aa36ad6", size = 44221, upload-time = "2025-10-26T15:12:10.434Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/14/1b/a298b06749107c305e1fe0f814c6c74aea7b2f1e10989cb30f544a1b3253/python_dotenv-1.2.1-py3-none-any.whl", hash = "sha256:b81ee9561e9ca4004139c6cbba3a238c32b03e4894671e181b671e8cb8425d61", size = 21230, upload-time = "2025-10-26T15:12:09.109Z" },
+]
+
+[[package]]
 name = "sniffio"
 version = "1.3.1"
 source = { registry = "https://pypi.org/simple" }
@@ -470,6 +479,7 @@ dependencies = [
     { name = "beautifulsoup4" },
     { name = "fastapi" },
     { name = "jinja2" },
+    { name = "python-dotenv" },
     { name = "sqlalchemy" },
     { name = "uvicorn" },
 ]
@@ -482,6 +492,7 @@ requires-dist = [
     { name = "beautifulsoup4", specifier = ">=4.13.4" },
     { name = "fastapi", specifier = ">=0.115.12" },
     { name = "jinja2", specifier = ">=3.1.6" },
+    { name = "python-dotenv", specifier = ">=1.2.1" },
     { name = "sqlalchemy", specifier = ">=2.0.41" },
     { name = "uvicorn", specifier = ">=0.34.2" },
 ]


### PR DESCRIPTION
# Descrição
O Dockerfile e compose anteriores estavam desatualizados, o que impossiblitava a build da imagem

# Mudanças
- Atualizei o DockerFile para suportar as novas dependencias do projeto, como por exemplo uv
- Adicionei suporte a adicionar os certificados em runtime no docker
- Alterei o local padrão dos localhost.key e localhost.crt para a pasta certs
- Atualizei o Readme para descrever a nescessidade dos arquivos SSL na pasta certs

Refs #13

